### PR TITLE
Reinclude functionality to enumerate unenumerated stereoisomers

### DIFF
--- a/scripts/scrub.py
+++ b/scripts/scrub.py
@@ -207,6 +207,7 @@ basic.add_argument("--name_from_prop", help="set molecule name from RDKit/SDF pr
 basic.add_argument("--ph", help="pH value for acid/base transformations", default=7.4, type=float)
 basic.add_argument("--skip_acidbase", help="skip enumeration of acid/base conjugates", action="store_true")
 basic.add_argument("--skip_tautomers", help="skip enumeration of tautomers", action="store_true")
+basic.add_argument("--skip_stereoisomers", help="skip enumeration of unenumerated stereoisomers, including those created by acid/base or tautomerization", action="store_true")
 basic.add_argument("--skip_ringfix", help="skip fixes of six-member rings", action="store_true")
 basic.add_argument("--skip_gen3d", help="skip generation of 3D coordinates (also skips ring fixes)", action="store_true")
 
@@ -334,6 +335,7 @@ scrub = Scrub(
     tauto_fname=None,
     skip_acidbase=args.skip_acidbase,
     skip_tautomers=args.skip_tautomers,
+    skip_stereoisomers=args.skip_stereoisomers,
     skip_ringfix=args.skip_ringfix,
     skip_gen3d=args.skip_gen3d,
     template=template_mol,

--- a/scrubber/core.py
+++ b/scrubber/core.py
@@ -547,7 +547,12 @@ class Scrub:
             # make a copy of the mols in pool to max sure we are properly detecting unenumerated chiral centers
             p = Chem.SmilesParserParams()
             p.removeHs=False
-            pool = [Chem.MolFromSmiles(Chem.MolToSmiles(mol)) for mol in pool]
+            tmp_pool = []
+            for mol in pool:
+                props = mol.GetPropsAsDict(includePrivate=True)
+                mol = Chem.MolFromSmiles(Chem.MolToSmiles(mol))
+                for prop, v in props.items():
+                    mol.SetProp(prop, v)
             # done with RDKit nonsense, do the actual enumeration
             molset = UniqueMoleculeContainer()
             for mol in pool:

--- a/scrubber/core.py
+++ b/scrubber/core.py
@@ -25,6 +25,7 @@ from .geom.geometry import GeometryGenerator
 from .transform.isomer import MoleculeIsomers
 from .protonate import AcidBaseConjugator
 from .protonate import Tautomerizer
+from .protonate import enumerate_stereoisomers
 from .common import UniqueMoleculeContainer
 from .ringfix import fix_rings
 from .espaloma_minim import EspalomaMinimizer
@@ -488,6 +489,7 @@ class Scrub:
         tauto_fname=None,
         skip_acidbase=False,
         skip_tautomers=False,
+        skip_stereoisomers=False,
         skip_ringfix=False,
         skip_gen3d=False,
         template = None,
@@ -506,6 +508,7 @@ class Scrub:
         self.ph_high = ph_high
         self.do_acidbase = not skip_acidbase
         self.do_tautomers = not skip_tautomers
+        self.do_stereoisomers = not skip_stereoisomers
         self.skip_ringfix = skip_ringfix # not avoiding negative to pass directly to gen3d
         self.do_gen3d = not skip_gen3d
         self.template = template
@@ -537,6 +540,18 @@ class Scrub:
             molset = UniqueMoleculeContainer()
             for mol in pool:
                 for mol_out in self.tautomerizer(mol): 
+                    molset.add(mol_out)
+            pool = list(molset)
+
+        if self.do_stereoisomers:
+            # make a copy of the mols in pool to max sure we are properly detecting unenumerated chiral centers
+            p = Chem.SmilesParserParams()
+            p.removeHs=False
+            pool = [Chem.MolFromSmiles(Chem.MolToSmiles(mol)) for mol in pool]
+            # done with RDKit nonsense, do the actual enumeration
+            molset = UniqueMoleculeContainer()
+            for mol in pool:
+                for mol_out in enumerate_stereoisomers(mol):
                     molset.add(mol_out)
             pool = list(molset)
 

--- a/scrubber/core.py
+++ b/scrubber/core.py
@@ -553,6 +553,8 @@ class Scrub:
                 mol = Chem.MolFromSmiles(Chem.MolToSmiles(mol))
                 for prop, v in props.items():
                     mol.SetProp(prop, v)
+                tmp_pool.append(mol)
+            pool = tmp_pool
             # done with RDKit nonsense, do the actual enumeration
             molset = UniqueMoleculeContainer()
             for mol in pool:

--- a/scrubber/protonate.py
+++ b/scrubber/protonate.py
@@ -4,6 +4,11 @@ from .common import DATA_PATH
 from rdkit import Chem
 from rdkit.Chem import AllChem
 from rdkit.Chem import rdChemReactions
+from rdkit.Chem.EnumerateStereoisomers import (
+    EnumerateStereoisomers,
+    StereoEnumerationOptions,
+    GetStereoisomerCount,
+)
 
 datapath = pathlib.Path(DATA_PATH) # convert from str to Path
 default_tautomers_fn = datapath / "tautomers.txt"
@@ -151,7 +156,7 @@ def react_and_sanitize(mol, rxn):
         product = product[0] # nr products == NumProductTemplates == 1
         try:
             s = Chem.SanitizeMol(product)
-            #product.UpdatePropertyCache()
+            product.UpdatePropertyCache()
             # loading a fresh molecule detects errors that updating the property cache doesn't
             product = Chem.MolFromSmiles(Chem.MolToSmiles(product))
             if product is None:
@@ -166,6 +171,31 @@ def react_and_sanitize(mol, rxn):
         output_products.append(product)
     return output_products
 
+
+def enumerate_stereoisomers(input_mol, unassigned_only=True, max_results=32) -> list:
+        """
+        source https://www.rdkit.org/docs/source/rdkit.Chem.EnumerateStereoisomers.html
+        """
+        opts = StereoEnumerationOptions(
+            unique=True,
+            tryEmbedding=False,
+            onlyUnassigned=unassigned_only,
+            maxIsomers=max_results,
+        )
+        isomers = UniqueMoleculeContainer([input_mol])
+        output = UniqueMoleculeContainer()
+        # process results and register the information of this transformation
+        for m in isomers:
+            print("[VERBOSE] processing molecule", Chem.MolToSmiles(m))
+            for ent in EnumerateStereoisomers(m, options=opts):
+                print(f"Made enantiomer {Chem.MolToSmiles(ent)}")
+                output.add(ent)
+
+        output = list(output)
+        for mol in output:
+            copy_mol_props(input_mol, mol)
+
+        return output
 
 def convert_recursive(mol, rxn, container):
     for product in react_and_sanitize(mol, rxn):


### PR DESCRIPTION
- Added function for enumerating unenumerated stereoisomers
- Function runs after acid/base and tautomerization, so will be performed on resulting acid/base and tautomer derivatives of initial molecule
- Default capped at generation of 32 isomers per mol

Manual testing performed with attached Jupyter notebook
[enumerate_unassigned_stereoisomers_example.ipynb.gz](https://github.com/forlilab/scrubber/files/15255870/enumerate_unassigned_stereoisomers_example.ipynb.gz)

