### PR TITLE
feat: option to enumerate stereoisomers -- recoded

### DIFF
--- a/molscrub/core.py
+++ b/molscrub/core.py
@@ -18,6 +18,7 @@ from .common import UniqueMoleculeContainer
 from .openff_toolkit import EspalomaMinimizer
 from .openff_toolkit import EspalomaCharger, NaglCharger
 from .geometry import gen3d
+from .protonate import enumerate_stereoisomers
 
 import joblib
 import tempfile
@@ -89,6 +90,7 @@ class Scrub:
         tauto_fname=None,
         skip_acidbase=False,
         skip_tautomers=False,
+        do_stereoisomers=False,
         skip_ringfix=False,
         skip_gen3d=False,
         template=None,
@@ -131,6 +133,7 @@ class Scrub:
         self.pka_model = pka_model
         self.model_file = model_file
         self.do_tautomers = not skip_tautomers
+        self.do_stereoisomers=do_stereoisomers
         self.skip_ringfix = (
             skip_ringfix  # not avoiding negative to pass directly to gen3d
         )
@@ -204,6 +207,25 @@ class Scrub:
             molset = UniqueMoleculeContainer()
             for mol in pool:
                 for mol_out in self.tautomerizer(mol):
+                    molset.add(mol_out)
+            pool = list(molset)
+
+        if self.do_stereoisomers:
+            # make a copy of the mols in pool to max sure we are properly detecting unenumerated chiral centers
+            p = Chem.SmilesParserParams()
+            p.removeHs=False
+            tmp_pool = []
+            for mol in pool:
+                props = mol.GetPropsAsDict(includePrivate=True)
+                mol = Chem.MolFromSmiles(Chem.MolToSmiles(mol))
+                for prop, v in props.items():
+                    mol.SetProp(prop, v)
+                tmp_pool.append(mol)
+            pool = tmp_pool
+            # done with RDKit nonsense, do the actual enumeration
+            molset = UniqueMoleculeContainer()
+            for mol in pool:
+                for mol_out in enumerate_stereoisomers(mol):
                     molset.add(mol_out)
             pool = list(molset)
 

--- a/molscrub/core.py
+++ b/molscrub/core.py
@@ -225,7 +225,7 @@ class Scrub:
             # done with RDKit nonsense, do the actual enumeration
             molset = UniqueMoleculeContainer()
             for mol in pool:
-                for mol_out in enumerate_stereoisomers(mol):
+                for mol_out in enumerate_stereoisomers(mol, debug=self.debug):
                     molset.add(mol_out)
             pool = list(molset)
 

--- a/molscrub/protonate.py
+++ b/molscrub/protonate.py
@@ -19,6 +19,11 @@ from itertools import combinations
 from typing import TypedDict
 from rdkit.Chem.rdChemReactions import ChemicalReaction
 import numpy.typing as npt
+from rdkit.Chem.EnumerateStereoisomers import (
+    EnumerateStereoisomers,
+    StereoEnumerationOptions,
+    GetStereoisomerCount,
+)
 
 
 

--- a/molscrub/protonate.py
+++ b/molscrub/protonate.py
@@ -723,6 +723,33 @@ def react_and_sanitize(mol, rxn):
     return output_products
 
 
+def enumerate_stereoisomers(input_mol, unassigned_only=True, max_results=32, debug=False) -> list:
+        """
+        source https://www.rdkit.org/docs/source/rdkit.Chem.EnumerateStereoisomers.html
+        """
+        opts = StereoEnumerationOptions(
+            unique=True,
+            tryEmbedding=False,
+            onlyUnassigned=unassigned_only,
+            maxIsomers=max_results,
+        )
+        isomers = UniqueMoleculeContainer([input_mol])
+        output = UniqueMoleculeContainer()
+        # process results and register the information of this transformation
+        for m in isomers:
+            if debug:
+                print("[VERBOSE] processing molecule", Chem.MolToSmiles(m))
+            for ent in EnumerateStereoisomers(m, options=opts):
+                if debug:
+                    print(f"Made enantiomer {Chem.MolToSmiles(ent)}")
+                output.add(ent)
+
+        output = list(output)
+        for mol in output:
+            copy_mol_props(input_mol, mol)
+
+        return output
+
 def convert_recursive(mol, rxn, container):
     for product in react_and_sanitize(mol, rxn):
         container.add(product)

--- a/scripts/scrub.py
+++ b/scripts/scrub.py
@@ -231,6 +231,7 @@ basic.add_argument("--skip_tautomers", help="skip enumeration of tautomers", act
 basic.add_argument("--skip_ringfix", help="skip fixes of six-member rings", action="store_true")
 basic.add_argument("--skip_gen3d", help="skip generation of 3D coordinates (also skips ring fixes)", action="store_true")
 basic.add_argument("--keep_all_frags", help="Keeps all mol fragments (default is to keep largest only)", action="store_true")
+basic.add_argument("--do_stereoisomers", help="enumerate stereoisomers, including those created by acid/base or tautomerization", action="store_true")
 
 misc = parser.add_argument_group("miscellaneous")
 misc.add_argument("--cpu", help="number of processes to run in parallel", default=0, type=int)
@@ -249,6 +250,7 @@ acidbase.add_argument("--pka_model", default="rules", choices=["rules", "etr1"],
                       "\"rules\" uses predetermined set of pka reactions for protonation.\n" +
                       "etr1 is an ML model for pKa determination " 
                       )
+
 
 geom = parser.add_argument_group("3D coordinates")
 
@@ -378,6 +380,7 @@ scrub = Scrub(
     tauto_fname=args.tauto_fname,
     skip_acidbase=args.skip_acidbase,
     skip_tautomers=args.skip_tautomers,
+    do_stereoisomers=args.do_stereoisomers,
     skip_ringfix=args.skip_ringfix,
     skip_gen3d=args.skip_gen3d,
     template=template_mol,

--- a/test/stereoisomer_test.py
+++ b/test/stereoisomer_test.py
@@ -1,0 +1,23 @@
+import pathlib
+from rdkit import Chem
+from molscrub.protonate import enumerate_stereoisomers
+
+
+test_smiles = 'BrC(Cl)(F)C=CC(O)C'
+test_mol = Chem.MolFromSmiles(test_smiles)
+expected_smiles = ["C[C@H](O)/C=C/[C@](F)(Cl)Br",
+"C[C@@H](O)/C=C/[C@](F)(Cl)Br",
+"C[C@H](O)/C=C/[C@@](F)(Cl)Br",
+"C[C@@H](O)/C=C/[C@@](F)(Cl)Br",
+"C[C@H](O)/C=C\\[C@](F)(Cl)Br",
+"C[C@@H](O)/C=C\\[C@](F)(Cl)Br",
+"C[C@H](O)/C=C\\[C@@](F)(Cl)Br",
+"C[C@@H](O)/C=C\\[C@@](F)(Cl)Br"]
+
+def test_stereoisomers():
+    isomers = enumerate_stereoisomers(test_mol)
+    isomers_smiles = [Chem.MolToSmiles(x) for x in isomers]
+
+    assert set(isomers_smiles) == set(expected_smiles)
+
+


### PR DESCRIPTION
This is mostly the same as #3, it was just easier to do a new PR. 

Changed `skip_stereoisomers` to `do_stereoisomers` so this option is False by default. As the enumeration of stereoisomers can generate a lot of structures, it might be better to have it off by default. 